### PR TITLE
add tags to biapy descr

### DIFF
--- a/collection.yaml
+++ b/collection.yaml
@@ -150,6 +150,7 @@ collection:
     documentation: https://biapy.readthedocs.io/en/latest/
     covers: ["https://raw.githubusercontent.com/danifranco/BiaPy-bioimage-io/main/logos/BiaPy_256.png"]
     icon: https://raw.githubusercontent.com/danifranco/BiaPy-bioimage-io/main/logos/BiaPy_512.png
+    tags: [software, biapy]
 
   #------------------------------------- Notebooks ---------------------------------------------
 


### PR DESCRIPTION
This PR should cause BiaPy to show up on the the bioimage.io website when filtering for software: 
https://bioimage.io/#/?type=application&tags=software